### PR TITLE
Use ULTIMAKER_CI_PAT as ghcr login so we can store the docker image cache in other repos

### DIFF
--- a/.github/workflows/prepare_env.yml
+++ b/.github/workflows/prepare_env.yml
@@ -120,7 +120,7 @@ jobs:
       - name: "Build Docker Image Cache"
         if: ${{ inputs.BUILD_DOCKER_CACHE }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+          echo "${{ secrets.ULTIMAKER_CI_PAT }}" | docker login ghcr.io -u $ --password-stdin
           ./build_for_ultimaker.sh -a build_docker_cache
 
       - name: Dump GitHub context


### PR DESCRIPTION
The current Prepare Environment workflows uses the GITHUB_TOKEN to store the cache, but that automatically links the docker image cache to the caller repository and do not allow us to link it to embedded-workflows.

We want to be free to link any package to embedded-workflows because this is a public repository and any package here, with public visibility, does not account on Ultimaker storage usage.

So I've changed the token to Ultimaker_CI, so the package will not be linked to the caller repository and can be freely linked to any other repo, including this one.