### PR TITLE
Add reusable workflow for pre-commit

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
In Ultimaker/marvin-service#147, it looks like we lost the workflow for running pre-commit as part of the CI pipeline for PRs. In order to be able to re-introduce this step, and also introduce this for other repos, recover this workflow definition as a re-usable one in *embedded-workflows*.