### PR TITLE
[CES-3197] Release packages for Debian Bookworm

### DIFF
--- a/.github/workflows/release_pkg.yml
+++ b/.github/workflows/release_pkg.yml
@@ -43,6 +43,7 @@ jobs:
             echo " "
             docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/buster /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
             docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/bullseye /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
+            docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/bookworm /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
           done;
          
       - name: Dump GitHub context


### PR DESCRIPTION
With this PR we extend support for Debian Bookworm and now release any built package to cloudsmith for that distribution too.