### PR TITLE
Remove bullseye package upload from workflow

### DIFF
--- a/.github/workflows/release_pkg.yml
+++ b/.github/workflows/release_pkg.yml
@@ -42,7 +42,6 @@ jobs:
             echo "########## Uploading ${package} ##########"
             echo " "
             docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/buster /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
-            docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/bullseye /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
             docker run -v "$(pwd):/build" cloudsmith-cli:latest cloudsmith push deb ultimaker/${{ env.RELEASE_REPO }}/debian/bookworm /build/${package} -k ${{ secrets.CLOUDSMITH_API_KEY }}
           done;
          


### PR DESCRIPTION
During the distribution upgrade process to Bookworm, we had transition builds that were Debian Bullseye based. Publicly we only support releases for Debian Buster (Old S-line printers) and Debian Bookworm so the release of packages for Debian Bullseye is no longer needed.