### PR TITLE
[CES-3466] Add a github action to prevent dev's merging !fixup commits

### DIFF
--- a/.github/workflows/fixup_commits.yml
+++ b/.github/workflows/fixup_commits.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
With this PR we add a simple action to remind a developer that their PR to be merged still contains !fixup commits. Merging will be blocked until no ore !fixup commits are present in the PR.