### PR TITLE
Bump github actions versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       RELEASE_VERSION: ${{ inputs.RELEASE_VERSION }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           submodules: recursive
@@ -37,7 +37,7 @@ jobs:
           ./build_for_ultimaker.sh -a build
           
       - name: Upload Artifact (Built package)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-package
           path: "./*.deb"

--- a/.github/workflows/fixup_commits.yml
+++ b/.github/workflows/fixup_commits.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.0.0
+    - uses: actions/checkout@v6
     - name: Block Fixup Commit Merge
       uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/prepare_env.yml
+++ b/.github/workflows/prepare_env.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Checkout Repository
         if: ${{ inputs.BUILD_DOCKER_CACHE }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           submodules: recursive

--- a/.github/workflows/release_docker_img.yml
+++ b/.github/workflows/release_docker_img.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           submodules: recursive

--- a/.github/workflows/release_pkg.yml
+++ b/.github/workflows/release_pkg.yml
@@ -14,14 +14,14 @@ jobs:
       RELEASE_REPO: ${{ inputs.RELEASE_REPO }}
     steps:
       - name: Cloning Embedded-Workflows on default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: Ultimaker/embedded-workflows
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           fetch-depth: 0
           path: embedded-workflows
           
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: build-package
           

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           submodules: recursive

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ULTIMAKER_CI_PAT }}
           submodules: recursive


### PR DESCRIPTION
Many outdated actions will stop working in September because Node.js 20 support will be removed by GitHub. This PR bumps the actions versions to use the up-to-date ones.
Since you are using only base actions, there is no risk of changed behavior. The same upgrade has been tested on multiple other repositories.